### PR TITLE
feat(errors): log stderr when encountering errors during exec

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,19 +22,19 @@ export default function () {
   if (type === 'major' || type === 'initial') return callback(null)
 
   exec('git fetch --tags', (error, stdout, stderr) => {
-    if (error) return callback(new Error('Could not fetch tags.'))
+    if (error) return callback(new Error('Could not fetch tags: `${stderr}`'))
     exec('git describe --abbrev=0 --tags', (descErr, stdout, stderr) => {
       gitRefs((err, refs) => {
-        if (err) return callback(new Error('Could not get refs.'))
+        if (err) return callback(new Error('Could not get refs: `${stderr}`'))
         let cohash = refs.get(descErr ? 'HEAD' : `tags/${stdout.trim()}`)
         exec(`git checkout ${cohash} ${opts.paths.join(' ')}`, (error, stdout, stderr) => {
-          if (error) return callback(new Error('Could not checkout paths.'))
+          if (error) return callback(new Error('Could not checkout paths: `${stderr}`'))
           let pkg = JSON.parse(readFileSync('package.json').toString())
           const tmpDep = pkg.dependencies
           delete pkg.dependencies
           writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
           exec('npm install', (error, stdout, stderr) => {
-            if (error) return callback(new Error('Could not install dependencies.'))
+            if (error) return callback(new Error('Could not install dependencies: `${stderr}`'))
             pkg.dependencies = tmpDep
             writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
             const npmTest = exec('npm test', (error, stdout, stderr) => {


### PR DESCRIPTION
This should make debugging easier by giving more information about what went wrong before the actual `npm test` run is reached in cracks' procedure.
